### PR TITLE
CI/PyPI: Test PyPI should only run on PRs to master, not on merges to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,10 @@ jobs:
       - name: Publish distribution to Test PyPI
         uses: pypa/gh-action-pypi-publish@master
         # # check if we need to distribute
-        if: needs.setup-py-changes.outputs.setup_changes == 'true'
+        if: |
+          needs.setup-py-changes.outputs.setup_changes == 'true' &&
+          github.event_name == 'pull_request' &&
+          github.ref == 'refs/heads/master'
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
**Changes:**
* Test PyPI step should only run if we are on a PR to master branch