### PR TITLE
PyPI: Rename graph-ein to ein-graph for PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ great for creating a standalone, single file graph database.
 To install the project, run the following:
 
 ```
-pip install graph-ein
+pip install ein-graph
 ```
 
 ## Usage

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setuptools.setup(
-    name="graph-ein",
+    name="ein-graph",
     version="0.0.9",
     author="Matthew Wimberly",
     author_email="matthew.wimb@gmail.com",


### PR DESCRIPTION
**Changes:**
* graph-ein is too similar to graphein, renamed to ein-graph for PyPI package 
* Updated pip install for readme